### PR TITLE
Fix broken War endpoint

### DIFF
--- a/api.json
+++ b/api.json
@@ -64,7 +64,7 @@
     "war": {
         "type": "id",
         "name": "War",
-        "path": "https://politicsandwar.com/api/war/${[ID]}&key=${[KEY]}"
+        "path": "/war/${[ID]}&key=${[KEY]}"
     },
     "wars": {
         "type": "id",

--- a/dist/api.json
+++ b/dist/api.json
@@ -64,7 +64,7 @@
     "war": {
         "type": "id",
         "name": "War",
-        "path": "https://politicsandwar.com/api/war/${[ID]}&key=${[KEY]}"
+        "path": "/war/${[ID]}&key=${[KEY]}"
     },
     "wars": {
         "type": "id",


### PR DESCRIPTION
Fixes the broken War endpoint
It was previously using an absolute URL, this change should allow users to use the `PoliticsAndWar.war()` method without rejection.